### PR TITLE
Allow Tags to display proper names when somebody accesses /tags/ for e.g.

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -17,9 +17,15 @@
 
     {{ range $name, $pages := .Data.Terms }}
       {{ $page := index $pages 0 }}
-      {{ $friendly := index $page.Page.Params $taxname 0 }}
       {{ $pageCount := len $pages }}
-      <a href="{{$base}}/{{$data.Plural}}/{{$name}}"> {{ $friendly }} </a> &nbsp;({{ $pageCount }} {{ if eq $pageCount 1 }}entry{{ else }}entries{{ end }})
+      {{ range $page.Page.Params.tags }}
+        {{ $urlized_term := . | lower | urlize }}
+        {{ if eq $urlized_term $name }}
+          <a href="{{$base}}/{{$data.Plural}}/{{$name}}">{{ . }} </a>
+          &nbsp;({{ $pageCount }} {{ if eq $pageCount 1 }}entry{{ else }}entries{{ end }})
+        {{end}}
+      {{end}}
+
 
 
       {{ $descpages := index $desctax $name }}


### PR DESCRIPTION
Currently if somebody is using the **hyde** theme, the default `terms.html` will display haphazard terms because the ***$friendly*** picks up wrong index values. We can modify the code to iterate over the tags and find the right one that matches the **$name** instead. 

If somebody add tags on their menu then **$friendly** variable will make the terms appear multiple number of times - even though the *href* is okay. 

After the code fix, the links will appear properly as follows:

```
Tags

    Beyond Compare  (1 entry) diff  (1 entry) discourse  (1 entry) errors  (1 entry) exceptions  (1 entry) executables  (2 entries) go  (19 entries) godoc  (1 entry) golang  (24 entries) interfaces  (1 entry) juju  (1 entry) myths  (1 entry) open source  (1 entry) package  (1 entry) persistence  (1 entry) plugins  (1 entry) pointers  (1 entry) programming  (19 entries) testing  (4 entries) 

```